### PR TITLE
[COOK-2428] account for `nil` @options

### DIFF
--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -2,6 +2,6 @@ search <%= @search %>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end %>
-<% unless @options.empty? -%>
+<% if @options && @options.any? -%>
 options <%= @options.map { |opt, val| val ? "#{opt}:#{val}" : opt }.sort.join(" ") %>
 <% end -%>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2428

addresses an issue in Chef 11
