### PR TITLE
Only add search option to resolv.conf if there is a search domain present

### DIFF
--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -1,4 +1,6 @@
+<% if @search && @search.present? -%>
 search <%= @search %>
+<% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end %>


### PR DESCRIPTION
Minor modification to only add the search option to resolv.conf if there is one.
