### PR TITLE
[COOK-4706] Make nameserver search fully configurable

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,35 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+# guard 'kitchen' do
+#   watch(%r{test/.+})
+#   watch(%r{^recipes/(.+)\.rb$})
+#   watch(%r{^attributes/(.+)\.rb$})
+#   watch(%r{^files/(.+)})
+#   watch(%r{^templates/(.+)})
+#   watch(%r{^providers/(.+)\.rb})
+#   watch(%r{^resources/(.+)\.rb})
+# end
+
+guard 'foodcritic', cookbook_paths: '.', all_on_start: false do
+  watch(/attributes\/.+\.rb$/)
+  watch(/providers\/.+\.rb$/)
+  watch(/recipes\/.+\.rb$/)
+  watch(/resources\/.+\.rb$/)
+  watch('metadata.rb')
+end
+
+guard 'rubocop', all_on_start: false do
+  watch(/attributes\/.+\.rb$/)
+  watch(/providers\/.+\.rb$/)
+  watch(/recipes\/.+\.rb$/)
+  watch(/resources\/.+\.rb$/)
+  watch('metadata.rb')
+end
+
+guard :rspec, cmd: 'bundle exec rspec', all_on_start: false, notification: false do
+  watch(/^libraries\/(.+)\.rb$/)
+  watch(/^spec\/(.+)_spec\.rb$/)
+  watch(/^(recipes)\/(.+)\.rb$/)   { |m| "spec/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')      { 'spec' }
+end

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See `attributes/default.rb` for default values.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See __Usage__.
 - `node['resolver']['options']` - a hash of resolv.conf options. See __Usage__ for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.
+- `node['resolver']['chef_search']` - the search query used for finding nameservers in the from_server_role recipe. The default value is in the recipe.
 
 Recipes
 -------

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,59 @@
+require 'bundler/setup'
+
+# Style tests. Rubocop and Foodcritic
+namespace :style do
+  require 'rubocop/rake_task'
+  desc 'Run Ruby style checks'
+  RuboCop::RakeTask.new(:ruby)
+
+  require 'foodcritic'
+  desc 'Run Chef style checks'
+  FoodCritic::Rake::LintTask.new(:chef) do |t|
+    t.options = {
+      fail_tags: ['any']
+    }
+  end
+end
+
+desc 'Run all style checks'
+task style: ['style:chef', 'style:ruby']
+
+# Rspec and ChefSpec
+require 'rspec/core/rake_task'
+desc 'Run ChefSpec examples'
+RSpec::Core::RakeTask.new(:spec)
+
+# Integration tests. Kitchen.ci
+require 'kitchen'
+namespace :integration do
+  desc 'Run Test Kitchen with Vagrant'
+  task :vagrant do
+    Kitchen.logger = Kitchen.default_file_logger
+    Kitchen::Config.new.instances.each do |instance|
+      instance.test(:always)
+    end
+  end
+
+  desc 'Run Test Kitchen with cloud plugins'
+  task :cloud do
+    run_kitchen = true
+    if ENV['TRAVIS'] == 'true' && ENV['TRAVIS_PULL_REQUEST'] != 'false'
+      run_kitchen = false
+    end
+
+    if run_kitchen
+      Kitchen.logger = Kitchen.default_file_logger
+      @loader = Kitchen::Loader::YAML.new(project_config: './.kitchen.cloud.yml')
+      config = Kitchen::Config.new(loader: @loader)
+      config.instances.each do |instance|
+        instance.test(:always)
+      end
+    end
+  end
+end
+
+desc 'Run all tests on Travis'
+task travis: ['style', 'spec', 'integration:cloud']
+
+# Default
+task default: ['style', 'spec', 'integration:vagrant']

--- a/metadata.rb
+++ b/metadata.rb
@@ -17,29 +17,29 @@ source_url 'https://github.com/chef-cookbooks/resolver' if respond_to?(:source_u
 issues_url 'https://github.com/chef-cookbooks/resolver/issues' if respond_to?(:issues_url)
 
 attribute 'resolver',
-  :display_name => 'Resolver',
-  :description => 'Hash of Resolver attributes',
-  :type => 'hash'
+  display_name: 'Resolver',
+  description: 'Hash of Resolver attributes',
+  type: 'hash'
 
 attribute 'resolver/search',
-  :display_name => 'Resolver Search',
-  :description => 'Default domain to search',
-  :default => 'domain'
+  display_name: 'Resolver Search',
+  description: 'Default domain to search',
+  default: 'domain'
 
 attribute 'resolver/nameservers',
-  :display_name => 'Resolver Nameservers',
-  :description => 'Default nameservers',
-  :type => 'array',
-  :default => []
+  display_name: 'Resolver Nameservers',
+  description: 'Default nameservers',
+  type: 'array',
+  default: []
 
 attribute 'resolver/options',
-  :display_name => 'Resolver Options',
-  :description => 'Default resolver options',
-  :type => 'hash',
-  :default => {}
+  display_name: 'Resolver Options',
+  description: 'Default resolver options',
+  type: 'hash',
+  default: {}
 
 attribute 'resolver/server_role',
-  :display_name => 'Resolver Server Role',
-  :description => 'Name of the role applied to the DNS resolver node',
-  :type => 'string',
-  :default => 'nameserver'
+  display_name: 'Resolver Server Role',
+  description: 'Name of the role applied to the DNS resolver node',
+  type: 'string',
+  default: 'nameserver'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@
 
 if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].empty?
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
-  Chef::Log.info("#{cookbook_name}::#{recipe_name} will exit to prevent a potential breaking change in /etc/resolv.conf.")
+  Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
 else
   template '/etc/resolv.conf' do

--- a/recipes/from_server_role.rb
+++ b/recipes/from_server_role.rb
@@ -26,8 +26,7 @@ nameservers =
   node['resolver']['nameservers']
 
 if nameservers.empty?
-  Chef::Log.warn("#{cookbook_name}::#{recipe_name} did not find any nameservers.")
-  Chef::Log.info("#{cookbook_name}::#{recipe_name} will exit to prevent a potential breaking change in /etc/resolv.conf.")
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} did not find any nameservers, skipping updating /etc/resolv.conf.")
   return
 end
 

--- a/recipes/from_server_role.rb
+++ b/recipes/from_server_role.rb
@@ -17,8 +17,11 @@
 # limitations under the License.
 #
 
+node.default_unless['resolver']['chef_search'] =
+  "role:#{node['resolver']['server_role']} AND chef_environment:#{node.chef_environment}"
+
 nameservers =
-  search(:node, "role:#{node['resolver']['server_role']} AND chef_environment:#{node.chef_environment}")
+  search(:node, "role:#{node['resolver']['server_role']} AND chef_environment:#{node.chef_environment}") # ~FC003
   .map { |node| node['ipaddress'] } +
   node['resolver']['nameservers']
 

--- a/spec/from_server_role_spec.rb
+++ b/spec/from_server_role_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'resolver::from_server_role' do
+  let(:chef_run) do
+    ChefSpec::ServerRunner.new do |node, server|
+      server.create_environment('development')
+      [1, 2].each do |n|
+        node = stub_node("node_#{n}.example.com", ohai: { fqdn: "node_#{n}.example.com", ipaddress: "10.0.0.#{n}" }) do |test_node|
+          test_node.run_list 'role[nameserver]'
+        end
+        server.create_node(node)
+      end
+    end.converge(described_recipe)
+  end
+
+  it 'populates resolv.conf with name servers' do
+    expect(chef_run).to render_file('/etc/resolv.conf').with_content('nameserver 10.0.0.1')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+# Added by ChefSpec
+require 'chefspec'
+
+ChefSpec::Coverage.start!
+
+RSpec.configure do |config|
+  config.order = 'random'
+end


### PR DESCRIPTION
I have added a chef_search attribute. I put it inside the recipe to allow backwards compatibility in case users were overriding the server_role attribute in a wrapper cookbook. I also pulled in some test files from the build-essential cookbook, with a minor fix to the Gemfile to fix a dependency problem.