### PR TITLE
improve safety and sanity of from_server_role resolver

### DIFF
--- a/recipes/from_server_role.rb
+++ b/recipes/from_server_role.rb
@@ -35,7 +35,7 @@ template "/etc/resolv.conf" do
   mode 0644
   variables(
     'search' => node['resolver']['search'],
-    'nameservers' => nameservers,
+    'nameservers' => nameservers.sort,
     'options' => node['resolver']['options']
   )
 end


### PR DESCRIPTION
Two main changes:
- don't create a resolv.conf with no nameservers
- sort the nameservers found by search
