### PR TITLE
Exclude search in template if the attribute is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 resolver Cookbook
 =================
-Configures /etc/resolv.conf, unless the nameservers attribute is empty.
+Configures /etc/resolv.conf, unless the nameservers attribute is empty. Search will be excluded if empty.
 
 
 Attributes

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -1,4 +1,6 @@
+<% unless @search.nil? -%>
 search <%= @search %>
+<% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>
 <% end %>


### PR DESCRIPTION
Do not include search in the template if the attribute is empty. There are times where I have a VM with no domain and having a blank search line in resolv.conf breaks functionality.
