### PR TITLE
search path update

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Attributes
 ----------
 See `attributes/default.rb` for default values.
 
-- `node['resolver']['search']` - Search list for host-name lookup.
+- `node['resolver']['search']` - Search list for host-name lookup. Limited to 6 elements and 256 characters.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See __Usage__.
 - `node['resolver']['options']` - a hash of resolv.conf options. See __Usage__ for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.
@@ -52,7 +52,7 @@ Using the default recipe, set the resolver attributes in a role, for example fro
 ```ruby
 "resolver" => {
   "nameservers" => ["10.13.37.120", "10.13.37.40"],
-  "search" => "int.example.org",
+  "search" => [ "int.example.org", "ext.example.org" ],
   "options" => {
     "timeout" => 2, "rotate" => nil
   }
@@ -62,7 +62,7 @@ Using the default recipe, set the resolver attributes in a role, for example fro
 The resulting `/etc/resolv.conf` will look like:
 
 ```text
-search int.example.org
+search int.example.org ext.example.org
 nameserver 10.13.37.120
 nameserver 10.13.37.40
 options timeout:2 rotate

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-default['resolver']['search'] = node['domain']
+default['resolver']['search'] = [ "#{node['domain']}" ]
 default['resolver']['domain'] = nil
 default['resolver']['nameservers'] = []
 default['resolver']['options'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Configures /etc/resolv.conf via attributes'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.3.1'
+version           '1.3.2'
 
 recipe 'resolver', 'Configures /etc/resolv.conf via attributes'
 recipe 'resolver::from_server_role', 'Manages nameservers from role with explicitly set servers'
@@ -24,7 +24,8 @@ attribute 'resolver',
 attribute 'resolver/search',
   display_name: 'Resolver Search',
   description: 'Default domain to search',
-  default: 'domain'
+  type: 'array',
+  default: [ 'domain' ]
 
 attribute 'resolver/nameservers',
   display_name: 'Resolver Nameservers',

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,10 @@ if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
+elsif node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
+  Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
+  return
 else
   template '/etc/resolv.conf' do
     source 'resolv.conf.erb'

--- a/recipes/from_server_role.rb
+++ b/recipes/from_server_role.rb
@@ -28,6 +28,10 @@ nameservers =
 if nameservers.empty?
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} did not find any nameservers, skipping updating /etc/resolv.conf.")
   return
+elsif node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
+  Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
+  return
 end
 
 template '/etc/resolv.conf' do

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -5,8 +5,8 @@
 <% unless @domain.nil? -%>
 domain <%= @domain %>
 <% end -%>
-<% unless @search.nil? -%>
-search <%= @search %>
+<% unless @search.empty? -%>
+search <%= @search.join(" ") %>
 <% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>


### PR DESCRIPTION
the search stanza should be an array rather than a single element.  resolv.conf search allows up to six search domains to be defined.  Have updated the recipes with some rules (no more than 6 domains or 256 chars), change the ['resolver']['search'] into an array and changed the template unless block to search for an empty array instead
