### PR TITLE
Allow multiple search domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configures /etc/resolv.conf, unless the nameservers attribute is empty. Search w
 
 See `attributes/default.rb` for default values.
 
-- `node['resolver']['search']` - Search list for host-name lookup.
+- `node['resolver']['search']` - Search list for host-name lookup. Limited to 6 elements and 256 characters.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See **Usage**.
 - `node['resolver']['options']` - a hash of resolv.conf options. See **Usage** for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.
@@ -46,7 +46,7 @@ Using the default recipe, set the resolver attributes in a role, for example fro
 ```ruby
 "resolver" => {
   "nameservers" => ["10.13.37.120", "10.13.37.40"],
-  "search" => "int.example.org",
+  "search" => [ "int.example.org", "ext.example.org" ],
   "options" => {
     "timeout" => 2, "rotate" => nil
   }
@@ -56,7 +56,7 @@ Using the default recipe, set the resolver attributes in a role, for example fro
 The resulting `/etc/resolv.conf` will look like:
 
 ```text
-search int.example.org
+search int.example.org ext.example.org
 nameserver 10.13.37.120
 nameserver 10.13.37.40
 options timeout:2 rotate

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configures /etc/resolv.conf, unless the nameservers attribute is empty. Search w
 
 See `attributes/default.rb` for default values.
 
-- `node['resolver']['search']` - Search list for host-name lookup. Limited to 6 elements and 256 characters.
+- `node['resolver']['search']` - a hash of search domains for host-name lookup; a string may also be provided for backwards compatibility. Limited to 6 elements and 256 characters.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See **Usage**.
 - `node['resolver']['options']` - a hash of resolv.conf options. See **Usage** for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Configures /etc/resolv.conf, unless the nameservers attribute is empty. Search w
 
 See `attributes/default.rb` for default values.
 
-- `node['resolver']['search']` - a hash of search domains for host-name lookup; a string may also be provided for backwards compatibility. Limited to 6 elements and 256 characters.
+- `node['resolver']['search']` - an array of search domains for host-name lookup; a string may also be provided for backwards compatibility. Limited to 6 elements and 256 characters.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See **Usage**.
 - `node['resolver']['options']` - a hash of resolv.conf options. See **Usage** for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-default['resolver']['search'] = [ "#{node['domain']}" ]
+default['resolver']['search'] = [node['domain'].to_s]
 default['resolver']['domain'] = nil
 default['resolver']['nameservers'] = []
 default['resolver']['options'] = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-default['resolver']['search'] = node['domain']
+default['resolver']['search'] = [ "#{node['domain']}" ]
 default['resolver']['domain'] = nil
 default['resolver']['nameservers'] = []
 default['resolver']['options'] = {}

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,7 @@ if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
-elsif node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256
+elsif node['resolver']['search'].is_a?(Array) && (node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256)
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,6 +28,10 @@ if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
+elsif node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
+  Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
+  return
 else
   t = template '/etc/resolv.conf' do
     source 'resolv.conf.erb'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,18 +28,19 @@ if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
-elsif node['resolver']['search'].is_a?(Array) && (node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256)
-  Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
-  Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
-  return
-else
-  t = template '/etc/resolv.conf' do
-    source 'resolv.conf.erb'
-    owner 'root'
-    group node['root_group']
-    mode '0644'
-    # This syntax makes the resolver sub-keys available directly
-    variables node['resolver']
-  end
-  t.atomic_update false if docker_guest?
 end
+
+if node['resolver']['search'].is_a?(Array) && (node['resolver']['search'].count > 6 || node['resolver']['search'].join.size > 256)
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} attribute ['resolver']['search'] can contain no more than 6 search domains and a total of 256 characters")
+  Chef::Log.warn("#{cookbook_name}::#{recipe_name} truncating resolv.conf search domain list to the first 6 entries.")
+end
+
+t = template '/etc/resolv.conf' do
+  source 'resolv.conf.erb'
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+  # This syntax makes the resolver sub-keys available directly
+  variables node['resolver']
+end
+t.atomic_update false if docker_guest?

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -6,7 +6,11 @@
 domain <%= @domain %>
 <% end -%>
 <% unless @search.empty? -%>
+<%   if @search.is_a?(Array) -%>
 search <%= @search.join(" ") %>
+<%   else -%>
+search <%= @search %>
+<%   end -%>
 <% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -7,7 +7,7 @@ domain <%= @domain %>
 <% end -%>
 <% unless @search.empty? -%>
 <%   if @search.is_a?(Array) -%>
-search <%= @search.join(" ") %>
+search <%= [@search].flatten[0..5].join(' ') %>
 <%   else -%>
 search <%= @search %>
 <%   end -%>

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -5,8 +5,8 @@
 <% unless @domain.nil? -%>
 domain <%= @domain %>
 <% end -%>
-<% unless @search.nil? -%>
-search <%= @search %>
+<% unless @search.empty? -%>
+search <%= @search.join(" ") %>
 <% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>


### PR DESCRIPTION
### Description

Provides multiple search domains by using an array, with backwards compatibility for a string value.

Builds on PR #21 from @dswebbthg by providing backwards compatibility.

### Issues Resolved

None

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
