### PR TITLE
Set manage_symlink_source to avoid the warning

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,7 @@ else
     mode '0644'
     # This syntax makes the resolver sub-keys available directly
     variables node['resolver']
+    manage_symlink_source true
   end
   t.atomic_update false if docker_guest?
 end


### PR DESCRIPTION
This avoids these warnings:

```
       Recipe: resolver::default
         * template[/etc/resolv.conf] action create[2017-10-20T22:07:34+00:00] WARN: File /etc/resolv.conf managed by template[/etc/resolv.conf] is really a symlink. Managing the source file instead.
       [2017-10-20T22:07:34+00:00] WARN: File /etc/resolv.conf managed by template[/etc/resolv.conf] is really a symlink. Managing the source file instead.
       [2017-10-20T22:07:34+00:00] WARN: Disable this warning by setting `manage_symlink_source true` on the resource
       [2017-10-20T22:07:34+00:00] WARN: Disable this warning by setting `manage_symlink_source true` on the resource
       [2017-10-20T22:07:34+00:00] WARN: In a future Chef release, 'manage_symlink_source' will not be enabled by default
       [2017-10-20T22:07:34+00:00] WARN: In a future Chef release, 'manage_symlink_source' will not be enabled by default
```

Signed-off-by: Tim Smith <tsmith@chef.io>