### PR TITLE
Newer versions of docker mount /etc/resolv.conf from the host resulting

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,14 +28,19 @@ if node['resolver']['nameservers'].empty? || node['resolver']['nameservers'][0].
   Chef::Log.warn("#{cookbook_name}::#{recipe_name} requires that attribute ['resolver']['nameservers'] is set.")
   Chef::Log.info("#{cookbook_name}::#{recipe_name} exiting to prevent a potential breaking change in /etc/resolv.conf.")
   return
-else
-  t = template '/etc/resolv.conf' do
-    source 'resolv.conf.erb'
-    owner 'root'
-    group node['root_group']
-    mode '0644'
-    # This syntax makes the resolver sub-keys available directly
-    variables node['resolver']
-  end
-  t.atomic_update false if docker_guest?
+end
+
+mount '/etc/resolv.conf' do
+  action :umount
+  device '/dev/sda1'
+  only_if { docker_guest? }
+end
+
+template '/etc/resolv.conf' do
+  source 'resolv.conf.erb'
+  owner 'root'
+  group node['root_group']
+  mode '0644'
+  # This syntax makes the resolver sub-keys available directly
+  variables node['resolver']
 end


### PR DESCRIPTION
in the following error:
```
Recipe: resolver::default
  * template[/etc/resolv.conf] action create

    ================================================================================
    Error executing action `create` on resource 'template[/etc/resolv.conf]'
    ================================================================================

    Errno::EBUSY
    ------------
    Device or resource busy @ rb_file_s_rename - (/etc/.chef-resolv20180116-21-1dn0bsl.conf, /etc/resolv.conf)
```
Unmounting /etc/resolv.conf allows the guest to manipulate the file.

Change-Id: I336ebe23e4cffdbe3a632be4d69732d2a2ca443b
Signed-off-by: Joe Nuspl <nuspl@nvwls.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [/] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [/] New functionality includes testing.
- [/] New functionality has been documented in the README if applicable
- [/] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
