### PR TITLE
add aix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Configures /etc/resolv.conf, unless the nameservers attribute is empty. Search w
 
 ### Platforms
 
+- AIX 
 - Debian/Ubuntu
 - RHEL/CentOS/Scientific/Amazon/Oracle
 - Fedora

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,11 @@ maintainer_email  'cookbooks@chef.io'
 license           'Apache-2.0'
 description       'Configures /etc/resolv.conf via attributes'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.1'
+version '2.0.2'
 
 recipe 'resolver', 'Configures /etc/resolv.conf via attributes'
 
-%w(ubuntu debian fedora centos redhat oracle scientific amazon freebsd openbsd mac_os_x solaris2 opensuse opensuseleap suse).each do |os|
+%w(aix ubuntu debian fedora centos redhat oracle scientific amazon freebsd openbsd mac_os_x solaris2 opensuse opensuseleap suse).each do |os|
   supports os
 end
 


### PR DESCRIPTION
Signed-off-by: Steve Clark <steve@bigsteve.us>

### Description

This change adds aix support. We have been using a fork of this for some time and forgot to provide the PR. 

### Issues Resolved

allows for the cookbook to support aix based hosts. 

### Check List

- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality has been documented in the README if applicable
- [X] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
