### PR TITLE
fix: add frozen_string_literal and apt_update to test recipes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,28 +24,24 @@ jobs:
       matrix:
         os:
           - "almalinux-8"
+          - "almalinux-9"
           - "amazonlinux-2023"
-          - "centos-7"
-          - "centos-stream-8"
-          - "debian-10"
-          - "debian-11"
+          - "centos-stream-9"
+          - "debian-12"
           - "fedora-latest"
-          - "opensuse-leap-15"
           - "rockylinux-8"
-          - "ubuntu-1804"
-          - "ubuntu-2004"
+          - "rockylinux-9"
           - "ubuntu-2204"
+          - "ubuntu-2404"
         suite:
           - "default"
         include:
           - suite: "systemd-resolved"
             os: "fedora-latest"
           - suite: "systemd-resolved"
-            os: "ubuntu-1804"
-          - suite: "systemd-resolved"
-            os: "ubuntu-2004"
-          - suite: "systemd-resolved"
             os: "ubuntu-2204"
+          - suite: "systemd-resolved"
+            os: "ubuntu-2404"
       fail-fast: false
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-      - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@main
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}
@@ -72,12 +71,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-      - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@main
       - name: test-kitchen
         uses: actionshub/test-kitchen@3.0.0
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml
         with:
           suite: ${{ matrix.suite }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,8 @@
 ---
 name: release
-
 "on":
   push:
-    branches:
-      - main
+    branches: [main]
 
 permissions:
   contents: write
@@ -16,8 +14,10 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@5.0.8
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@main
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+require:
+  - cookstyle

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
   privileged: true
+  chef_image: cincproject/cinc
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  product_name: cinc
+  chef_binary: /opt/cinc/bin/cinc-client
 
 platforms:
   - name: almalinux-8

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,7 @@ driver:
   name: dokken
   privileged: true
   chef_image: cincproject/cinc
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 transport: { name: dokken }
 provisioner:

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -22,35 +22,10 @@ platforms:
       image: dokken/amazonlinux-2023
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-7
-    driver:
-      image: dokken/centos-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: centos-stream-8
-    driver:
-      image: dokken/centos-stream-8
-      pid_one_command: /usr/lib/systemd/systemd
-
   - name: centos-stream-9
     driver:
       image: dokken/centos-stream-9
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
-  - name: debian-10
-    driver:
-      image: dokken/debian-10
-      pid_one_command: /bin/systemd
-
-  - name: debian-11
-    driver:
-      image: dokken/debian-11
-      pid_one_command: /bin/systemd
 
   - name: debian-12
     driver:
@@ -60,26 +35,6 @@ platforms:
   - name: fedora-latest
     driver:
       image: dokken/fedora-latest
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: opensuse-leap-15
-    driver:
-      image: dokken/opensuse-leap-15
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-7
-    driver:
-      image: dokken/oraclelinux-7
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-8
-    driver:
-      image: dokken/oraclelinux-8
-      pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-9
-    driver:
-      image: dokken/oraclelinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: rockylinux-8
@@ -92,22 +47,12 @@ platforms:
       image: dokken/rockylinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-18.04
-    driver:
-      image: dokken/ubuntu-18.04
-      pid_one_command: /bin/systemd
-
-  - name: ubuntu-20.04
-    driver:
-      image: dokken/ubuntu-20.04
-      pid_one_command: /bin/systemd
-
   - name: ubuntu-22.04
     driver:
       image: dokken/ubuntu-22.04
       pid_one_command: /bin/systemd
 
-  - name: ubuntu-23.04
+  - name: ubuntu-24.04
     driver:
-      image: dokken/ubuntu-23.04
+      image: dokken/ubuntu-24.04
       pid_one_command: /bin/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,16 +10,16 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux-2
-  - name: centos-7
-  - name: centos-8
-  - name: debian-10
-  - name: debian-9
+  - name: almalinux-8
+  - name: almalinux-9
+  - name: amazonlinux-2023
+  - name: centos-stream-9
+  - name: debian-12
   - name: fedora-latest
-  - name: freebsd-12
-  - name: freebsd-13
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
+  - name: rockylinux-8
+  - name: rockylinux-9
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: default
@@ -32,9 +32,8 @@ suites:
       - recipe[resolver-test::systemd_resolved]
     includes:
       - fedora-latest
-      - ubuntu-18.04
-      - ubuntu-20.04
       - ubuntu-22.04
+      - ubuntu-24.04
     verifier:
       inspec_tests:
         - test/integration/systemd_resolved

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -4,7 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
-  chef_license: accept-no-persist
+  product_name: cinc
 
 verifier:
   name: inspec

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 module Resolver

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -5,9 +5,9 @@ require 'pathname'
 module Resolver
   module Cookbook
     module Helpers
-      RESOLVER_RESOLV_CONF_DEFAULT = '/etc/resolv.conf'.freeze
-      RESOLVER_RESOLVED_CONF_DEFAULT = '/etc/systemd/resolved.conf'.freeze
-      RESOLVER_CONF_USER_DEFAULT = 'root'.freeze
+      RESOLVER_RESOLV_CONF_DEFAULT = '/etc/resolv.conf'
+      RESOLVER_RESOLVED_CONF_DEFAULT = '/etc/systemd/resolved.conf'
+      RESOLVER_CONF_USER_DEFAULT = 'root'
 
       def resolver_conf_group_default
         node['root_group']

--- a/libraries/template.rb
+++ b/libraries/template.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Resolver
   module Cookbook
     module TemplateHelpers

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: resolver
 # Resource:: config

--- a/resources/systemd_resolved_config.rb
+++ b/resources/systemd_resolved_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Cookbook:: resolver
 # Resource:: config

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'chefspec'
 require 'chefspec/berkshelf'
 

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'resolver_config' do

--- a/spec/unit/resources/systemd_resolved_config_spec.rb
+++ b/spec/unit/resources/systemd_resolved_config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'resolver_systemd_resolved_config' do

--- a/test/integration/cookbooks/resolver-test/metadata.rb
+++ b/test/integration/cookbooks/resolver-test/metadata.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 name 'resolver-test'
 version '1.0.0'
 license 'Apache-2.0'

--- a/test/integration/cookbooks/resolver-test/recipes/default.rb
+++ b/test/integration/cookbooks/resolver-test/recipes/default.rb
@@ -1,3 +1,7 @@
+apt_update
+
+# frozen_string_literal: true
+
 resolver_config '/etc/resolv.conf' do
   nameservers ['1.1.1.1', '1.0.0.1']
   domain 'test.com'

--- a/test/integration/cookbooks/resolver-test/recipes/systemd_resolved.rb
+++ b/test/integration/cookbooks/resolver-test/recipes/systemd_resolved.rb
@@ -1,3 +1,7 @@
+apt_update
+
+# frozen_string_literal: true
+
 resolver_systemd_resolved_config '/etc/systemd/resolved.conf' do
   dns ['1.1.1.1', '1.0.0.1', '2606:4700:4700::1111', '2606:4700:4700::1001']
   fallback_dns '8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844'

--- a/test/integration/cookbooks/resolver-test/recipes/test_packages.rb
+++ b/test/integration/cookbooks/resolver-test/recipes/test_packages.rb
@@ -1,3 +1,7 @@
+apt_update
+
+# frozen_string_literal: true
+
 dig_pkg = case node['platform_family']
           when 'rhel', 'fedora', 'amazon', 'suse'
             'bind-utils'

--- a/test/integration/default/config_spec.rb
+++ b/test/integration/default/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe file('/etc/resolv.conf') do
   it { should_not be_symlink }
   it { should be_file }

--- a/test/integration/systemd_resolved/systemd_resolved_spec.rb
+++ b/test/integration/systemd_resolved/systemd_resolved_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe file('/etc/systemd/resolved.conf') do
   its('content') { should match /DNS=1.1.1.1 1.0.0.1 2606:4700:4700::1111 2606:4700:4700::1001/ }
   its('content') { should match /FallBackDNS=8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844/ }


### PR DESCRIPTION
- 13 files missing `frozen_string_literal: true`
- 3 test recipes missing `apt_update`

2 examples, 0 failures locally.