### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 #
 #     steps:
 #       - name: Check out code
-#         uses: actions/checkout@v3
+#         uses: actions/checkout@v7
 #       - name: Install Chef
 #         uses: actionshub/chef-install@2.0.4
 #       - name: test-kitchen

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,0 @@
-source 'https://supermarket.chef.io'
-
-cookbook 'resolver-test', path: './test/integration/cookbooks/resolver-test'
-
-metadata

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'resolver'
+
+run_list 'recipe[resolver-test::test_packages]', 'recipe[resolver-test::default]'
+
+cookbook 'resolver', path: '.'
+cookbook 'resolver-test', path: './test/integration/cookbooks/resolver-test'
+
+Dir.children('./test/integration/cookbooks/resolver-test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'resolver-test::' + recipe_name
+end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -9,6 +9,9 @@ cookbook 'resolver-test', path: './test/integration/cookbooks/resolver-test'
 
 Dir.children('./test/integration/cookbooks/resolver-test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
+  next if recipe_name == 'systemd_resolved'
 
   named_run_list recipe_name.to_sym, 'resolver-test::' + recipe_name
 end
+
+named_run_list :systemd_resolved, 'resolver-test::test_packages', 'resolver-test::systemd_resolved'

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/documentation/resolver_systemd_resolved_config.md
+++ b/documentation/resolver_systemd_resolved_config.md
@@ -12,8 +12,10 @@ Introduced: v3.0.0
 
 ## Properties
 
+<!-- markdownlint-disable MD060 -->
+
 | Name                   | Type          | Default                          | Description                                                         |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- |
+| --- | --- | --- | --- |
 | `config_file`          | String        | `/etc/systemd/resolved.conf`     | The path to the systemd-resolved configuration file on disk         |
 | `cookbook`             | String        | `resolver`                       | Cookbook to source configuration file template from                 |
 | `template`             | String        | `resolved.conf.erb`              | Template to use to generate the configuration file                  |
@@ -30,9 +32,11 @@ Introduced: v3.0.0
 | `cache`                | True, False, String | `true`                     | Control DNS caching on the host                                     |
 | `cache_from_localhost` | True, False   | `false`                          | Control DNS caching of a result from a local address on the host    |
 | `dns_stub_listener`    | True, False, String | `nil`                      | Control the DNS stub listener on the host                           |
-| `dns_stub_listener_extra` | True, False, String | `nil`                   |Additional DNS stub sockets to listen on for the host                |
+| `dns_stub_listener_extra` | True, False, String | `nil`                   | Additional DNS stub sockets to listen on for the host               |
 | `read_etc_hosts`       | True, False   | `true`                           | Control resolution of a hostname from the /etc/hosts file           |
 | `resolve_unicast_single_label` | True, False | `false`                    | Control resolution of A and AAAA queries for single-label names over classic DNS |
+
+<!-- markdownlint-enable MD060 -->
 
 ## Examples
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,6 +27,8 @@ suites:
       - recipe[resolver-test::test_packages]
       - recipe[resolver-test::default]
   - name: systemd_resolved
+    provisioner:
+      named_run_list: systemd_resolved
     run_list:
       - recipe[resolver-test::test_packages]
       - recipe[resolver-test::systemd_resolved]

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -18,6 +18,7 @@
 #
 
 unified_mode true
+provides :resolver_config
 
 include Resolver::Cookbook::Helpers
 

--- a/resources/systemd_resolved_config.rb
+++ b/resources/systemd_resolved_config.rb
@@ -18,6 +18,7 @@
 #
 
 unified_mode true
+provides :resolver_systemd_resolved_config
 
 include Resolver::Cookbook::Helpers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress